### PR TITLE
IImapClient cleanup

### DIFF
--- a/IImapClient.cs
+++ b/IImapClient.cs
@@ -563,10 +563,5 @@ namespace S22.Imap
         /// <seealso cref="SetMessageFlags"/>
         /// <seealso cref="AddMessageFlags"/>
         void RemoveMessageFlags(uint uid, string mailbox, params MessageFlag[] flags);
-
-        /// <summary>
-        /// Releases all resources used by this ImapClient object.
-        /// </summary>
-        void Dispose();
     }
 }

--- a/IImapClient.cs
+++ b/IImapClient.cs
@@ -3,7 +3,7 @@ using System.Net.Mail;
 
 namespace S22.Imap
 {
-    public interface IImapClient
+    public interface IImapClient: IDisposable
     {
         /// <summary>
         /// The default mailbox to operate on, when no specific mailbox name was indicated

--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -16,7 +16,7 @@ namespace S22.Imap {
 	/// Allows applications to communicate with a mail server by using the
 	/// Internet Message Access Protocol (IMAP).
 	/// </summary>
-	public class ImapClient : IDisposable, IImapClient
+	public class ImapClient : IImapClient
 	{
 		private Stream stream;
 		private TcpClient client;

--- a/S22.Imap.csproj
+++ b/S22.Imap.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Bodystructure\Reader.cs" />
     <Compile Include="FetchOptions.cs" />
     <Compile Include="IdleEvents.cs" />
+    <Compile Include="IImapClient.cs" />
     <Compile Include="ImapClient.cs" />
     <Compile Include="Exceptions.cs" />
     <Compile Include="MailboxInfo.cs" />


### PR DESCRIPTION
I neglected to mark the interface as disposable preventing me from using it as an IDisposable when using the interface, corrected this issue.
