### PR TITLE
Added support for bulk operations to CopyMessage and DeleteMessage methods.

### DIFF
--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -1557,6 +1557,8 @@ namespace S22.Imap {
         {
             if (!Authed)
                 throw new NotAuthenticatedException();
+            if (set.Count == 0)
+                return;
             lock (sequenceLock)
             {
                 PauseIdling();
@@ -1634,6 +1636,8 @@ namespace S22.Imap {
         {
             if (!Authed)
                 throw new NotAuthenticatedException();
+            if (set.Count == 0)
+                return;
             lock (sequenceLock)
             {
                 PauseIdling();

--- a/MessageSet.cs
+++ b/MessageSet.cs
@@ -48,6 +48,18 @@ namespace S22.Imap
         }
 
         /// <summary>
+        /// Returns the number of unique message IDs in the set.
+        /// </summary>
+        /// <returns></returns>
+        public int Count
+        {
+            get
+            {
+                return _ids.Count;
+            }
+        }
+
+        /// <summary>
         /// Adds a message id to the set, if it does not already exist.
         /// </summary>
         /// <param name="id"></param>

--- a/MessageSet.cs
+++ b/MessageSet.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace S22.Imap
+{
+    public class MessageSet
+    {
+        /// <summary>
+        /// Initializes a new instance of the MessageSet class.
+        /// </summary>
+        public MessageSet() { }
+
+        /// <summary>
+        /// Initializes a new instance of the MessageSet class,
+        /// and adds the given id to the set.
+        /// </summary>
+        /// <param name="id"></param>
+        public MessageSet(uint id)
+        {
+            Add(id);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the MessageSet class,
+        /// and adds the given list of ids to the set.
+        /// </summary>
+        /// <param name="ids"></param>
+        public MessageSet(IEnumerable<uint> ids)
+        {
+            Add(ids);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the MessageSet class,
+        /// and adds the given range of ids to the set.
+        /// </summary>
+        /// <param name="fromId"></param>
+        /// <param name="toId"></param>
+        public MessageSet(uint fromId, uint toId)
+        {
+            AddRange(fromId, toId);
+        }
+
+        private SortedSet<uint> _ids = new SortedSet<uint>();
+
+        /// <summary>
+        /// Adds a message id to the set, if it does not already exist.
+        /// </summary>
+        /// <param name="id"></param>
+        public void Add(uint id)
+        {
+            _ids.Add(id);
+        }
+
+        /// <summary>
+        /// Adds a list of ids to the set, where they do not already exist.
+        /// </summary>
+        /// <param name="ids"></param>
+        public void Add(IEnumerable<uint> ids)
+        {
+            foreach (uint id in ids)
+                Add(id);
+        }
+
+        /// <summary>
+        /// Adds a range of ids to the set, where they do not already exist.
+        /// </summary>
+        /// <param name="fromId"></param>
+        /// <param name="toId"></param>
+        public void AddRange(uint fromId, uint toId)
+        {
+            if (fromId > toId)
+                throw new ArgumentException("The second range value must be greater than or equal to the first.");
+            //Just add them to the list for now. It makes it easier to convert to ranges later
+            //if we are just starting from an int list.
+            for (uint i = fromId; i <= toId; i++)
+                _ids.Add(i);
+        }
+
+        /// <summary>
+        /// Returns a message set string ready for use in IMAP commands.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            IList<Tuple<uint, uint>> ranges = convertIDsToRanges();
+            IEnumerable<uint> ids = removeIDsInRanges(ranges);
+            IList<string> values = ids.Select(i => i.ToString()).ToList();
+            foreach (Tuple<uint, uint> t in ranges)
+                values.Add(string.Concat(t.Item1 + ":" + t.Item2));
+            return string.Join(",", values);
+        }
+
+        /// <summary>
+        /// Converts contiguous ids to ranges and removes them from the id list.
+        /// </summary>
+        private IList<Tuple<uint, uint>> convertIDsToRanges()
+        {
+            IList<Tuple<uint, uint>> ranges = new List<Tuple<uint, uint>>();
+            uint? start = null;
+            for (int i = 0; i < _ids.Count; i++)
+            {
+                uint id = _ids.ElementAt(i);
+                if (start == null)
+                    start = id;
+                if (id - start > 1)
+                {
+                    if ((id != _ids.ElementAt(i - 1) + 1)) //previous item is last of contiguous set
+                    {
+                        ranges.Add(new Tuple<uint, uint>(start.Value, _ids.ElementAt(i - 1)));
+                        start = id;
+                    }
+                    else if (i == _ids.Count - 1) //we're on the last item
+                    {
+                        ranges.Add(new Tuple<uint, uint>(start.Value, id));
+                    }
+                }
+            }
+            return ranges;
+            
+        }
+
+        /// <summary>
+        /// Removes any ids from the list that are already covered by ranges
+        /// </summary>
+        private IEnumerable<uint> removeIDsInRanges(IList<Tuple<uint, uint>> ranges)
+        {
+            IList<uint> ids = new List<uint>();
+            for (int i = _ids.Count - 1; i > -1; i--)
+                if (!rangeContains(ranges, _ids.ElementAt(i)))
+                    ids.Add(_ids.ElementAt(i));
+            return ids;
+        }
+
+        /// <summary>
+        /// Returns true if a range already covers a given id.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        private bool rangeContains(IList<Tuple<uint, uint>> ranges, uint id)
+        {
+            foreach (var r in ranges)
+                if (id >= r.Item1 && id <= r.Item2)
+                    return true;
+            return false;
+        }
+    }
+}

--- a/MessageSet.cs
+++ b/MessageSet.cs
@@ -98,25 +98,35 @@ namespace S22.Imap
         private IList<Tuple<uint, uint>> convertIDsToRanges()
         {
             IList<Tuple<uint, uint>> ranges = new List<Tuple<uint, uint>>();
-            uint? start = null;
+
+            int? startIndex = null;
+            bool inRange = false;
             for (int i = 0; i < _ids.Count; i++)
             {
-                uint id = _ids.ElementAt(i);
-                if (start == null)
-                    start = id;
-                if (id - start > 1)
+                if (startIndex == null)
                 {
-                    if ((id != _ids.ElementAt(i - 1) + 1)) //previous item is last of contiguous set
-                    {
-                        ranges.Add(new Tuple<uint, uint>(start.Value, _ids.ElementAt(i - 1)));
-                        start = id;
-                    }
-                    else if (i == _ids.Count - 1) //we're on the last item
-                    {
-                        ranges.Add(new Tuple<uint, uint>(start.Value, id));
-                    }
+                    startIndex = i;
+                    continue;
                 }
+                if ((_ids.ElementAt(i) - _ids.ElementAt(startIndex.Value) == i - startIndex) && i != _ids.Count - 1)
+                {
+                    inRange = true;
+                    continue; //contiguous
+                }
+                else if (_ids.ElementAt(i) - _ids.ElementAt(startIndex.Value) != i - startIndex)
+                {
+                    ranges.Add(new Tuple<uint, uint>(_ids.ElementAt(startIndex.Value), _ids.ElementAt(i - 1)));
+                    inRange = false;
+                    startIndex = i;
+                }
+                else if (i == _ids.Count - 1 && inRange)
+                {
+                    ranges.Add(new Tuple<uint, uint>(_ids.ElementAt(startIndex.Value), _ids.ElementAt(i)));
+                }
+
             }
+
+
             return ranges;
             
         }

--- a/S22.Imap.csproj
+++ b/S22.Imap.csproj
@@ -75,6 +75,7 @@
     <Compile Include="MailMessage.cs" />
     <Compile Include="MessageBuilder.cs" />
     <Compile Include="MessageFlags.cs" />
+    <Compile Include="MessageSet.cs" />
     <Compile Include="MIMEPart.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SafeQueue.cs" />

--- a/Tests/MessageSetTest.cs
+++ b/Tests/MessageSetTest.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace S22.Imap.Test
+{
+    /// <summary>
+    /// Contains unit tests for the MessageSet class
+    /// </summary>
+    [TestClass]
+    public class MessageSetTest
+    {
+        [TestMethod]
+        [TestCategory("MessageSet")]
+        public void CollapseOverlappingRanges()
+        {
+            var set = new MessageSet();
+            set.AddRange(1, 3);
+            set.AddRange(2, 4);
+            Assert.AreEqual("1:4", set.ToString());
+        }
+
+        [TestMethod]
+        [TestCategory("MessageSet")]
+        public void CollapseContiguousRanges()
+        {
+            var set = new MessageSet();
+            set.AddRange(1, 3);
+            set.AddRange(4, 6);
+            Assert.AreEqual("1:6", set.ToString());
+        }
+
+        [TestMethod]
+        [TestCategory("MessageSet")]
+        public void RemoveDuplicateIDs()
+        {
+            var set = new MessageSet();
+            set.Add(1);
+            set.Add(1);
+            Assert.AreEqual("1", set.ToString());
+        }
+
+        [TestMethod]
+        [TestCategory("MessageSet")]
+        public void IDsDoNotOverlapRanges()
+        {
+            var set = new MessageSet();
+            set.AddRange(1, 3);
+            set.Add(2);
+            Assert.AreEqual("1:3", set.ToString());
+        }
+
+        [TestMethod]
+        [TestCategory("MessageSet")]
+        public void RangesDoNotOverlapIDs()
+        {
+            var set = new MessageSet();
+            set.Add(2);
+            set.AddRange(1, 3);
+            Assert.AreEqual("1:3", set.ToString());
+        }
+
+
+        [TestMethod]
+        [TestCategory("MessageSet")]
+        public void RangesAndIDs()
+        {
+            var set = new MessageSet();
+            set.Add(1);
+            set.AddRange(3, 5);
+            set.Add(7);
+            Assert.AreEqual("1,3:5,7", set.ToString());
+        }
+    }
+}

--- a/Tests/MessageSetTest.cs
+++ b/Tests/MessageSetTest.cs
@@ -59,7 +59,6 @@ namespace S22.Imap.Test
             Assert.AreEqual("1:3", set.ToString());
         }
 
-
         [TestMethod]
         [TestCategory("MessageSet")]
         public void RangesAndIDs()
@@ -69,6 +68,40 @@ namespace S22.Imap.Test
             set.AddRange(3, 5);
             set.Add(7);
             Assert.AreEqual("1,3:5,7", set.ToString());
+        }
+
+        [TestMethod]
+        [TestCategory("MessageSet")]
+        public void RemoveID()
+        {
+            var set = new MessageSet();
+            set.Add(1);
+            set.Add(7);
+            set.Remove(1);
+            Assert.AreEqual("7", set.ToString());
+        }
+
+        [TestMethod]
+        [TestCategory("MessageSet")]
+        public void RemoveRange()
+        {
+            var set = new MessageSet();
+            set.AddRange(1,5);
+            set.RemoveRange(1,3);
+            Assert.AreEqual("4:5", set.ToString());
+        }
+
+
+        [TestMethod]
+        [TestCategory("MessageSet")]
+        public void Constructors()
+        {
+            var set = new MessageSet();
+            Assert.AreEqual("", set.ToString());
+            set = new MessageSet(1);
+            Assert.AreEqual("1", set.ToString());
+            set = new MessageSet(new uint[]{1,2,3});
+            Assert.AreEqual("1:3", set.ToString());
         }
     }
 }

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -75,6 +75,7 @@
     <Compile Include="PlainTest.cs" />
     <Compile Include="OAuth2Test.cs" />
     <Compile Include="SrpTest.cs" />
+    <Compile Include="MessageSetTest.cs" />
     <Compile Include="UTF7Test.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I found there was quite a bit of overhead when processing many messages one at a time, so I added overloads to be able to process many messages at once.

I implemented this via a `MessageSet` class that de-dupes and collapses a list of integers into ranges using IMAP's message set format, e.g., {1,2,3,4,5,7} gets converted into "1:5,7".

Note: I made no changes to `IIMapClient`.
