### PR TITLE
Add line to handle Exception thrown :{An invalid character was found in ...

### DIFF
--- a/MessageBuilder.cs
+++ b/MessageBuilder.cs
@@ -152,6 +152,7 @@ namespace S22.Imap {
 			try {
 				// .NET won't accept address-lists ending with a ';' character.
 				list = list.TrimEnd(';');
+			        list = list.TrimEnd(',');
 				// Check for minimal length requirement.
 				if (list.TrimStart('<').TrimEnd('>').Length < minValidLength)
 					return mails.ToArray();


### PR DESCRIPTION
Add line to handle Exception thrown :{An invalid character was found in the mail header: ','.

list = list.TrimEnd(',');
the email I read has ',' at the end of ' To 'adresses
