### PR TITLE
Apple Mail sends attachments as inline are are marked as alternate views

### DIFF
--- a/MessageBuilder.cs
+++ b/MessageBuilder.cs
@@ -370,8 +370,7 @@ namespace S22.Imap {
 			// Many attachments are missing the disposition-type. If it's not defined as alternative
 			// and it has a name attribute, assume it is Attachment rather than an AlternateView.
 			if (part.Disposition.Type == ContentDispositionType.Attachment ||
-				(part.Disposition.Type == ContentDispositionType.Unknown &&
-				preferAlternative == false && hasName))
+				(preferAlternative == false && hasName))
 				message.Attachments.Add(CreateAttachment(part, bytes));
 			else
 				message.AlternateViews.Add(CreateAlternateView(part, bytes));

--- a/MessageBuilder.cs
+++ b/MessageBuilder.cs
@@ -356,7 +356,7 @@ namespace S22.Imap {
 			// (i.e. spam) mails like to omit content-types so we don't check for that here and just
 			// assume it's text.
 			if (String.IsNullOrEmpty(message.Body) &&
-				part.Disposition.Type != ContentDispositionType.Attachment) {
+				part.Type == S22.Imap.ContentType.Text) {
 				message.Body = encoding.GetString(bytes);
 				message.BodyEncoding = encoding;
 				message.IsBodyHtml = part.Subtype.ToLower() == "html";


### PR DESCRIPTION
Apple Mail sends attachments as inline are are marked as alternate views and the name of the attachment is lost.

The behavious can be changed http://katiefloyd.me/blog/get-rid-of-inline-attachments-in-apple-mail otherwise an attachment will look like this:

Content-Type: multipart/mixed; boundary=Apple-Mail-2--769176039

--Apple-Mail-2--769176039
Content-Transfer-Encoding: 7bit
Content-Type: text/plain;
 charset=us-ascii

Hello
--Apple-Mail-2--769176039
Content-Disposition: inline;
 filename=" xxx.pdf"
Content-Type: application/pdf;
 name=" xxx.pdf"
Content-Transfer-Encoding: base64
