### PR TITLE
Use current Windows user context when specifying NTLM over SSPI without ...

### DIFF
--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -360,7 +360,7 @@ namespace S22.Imap {
 				using (NegotiateStream ns = new NegotiateStream(fs, true)) {
 					try {
 						ns.AuthenticateAsClient(
-							new NetworkCredential(username, password),
+							useNtlm && username == string.Empty ? CredentialCache.DefaultNetworkCredentials : new NetworkCredential(username, password), 
 							null,
 							String.Empty,
 							useNtlm ? ProtectionLevel.None : ProtectionLevel.EncryptAndSign,


### PR DESCRIPTION
...passing a username.
