### PR TITLE
Dev

### DIFF
--- a/Examples.xml
+++ b/Examples.xml
@@ -335,54 +335,11 @@
 			<example>
 				This example demonstrates how to store a mail message on an IMAP server.
 				<code>
-					ImapClient Client = new ImapClient("imap.gmail.com", 993, "My_UsernamMe",
-					"My_Password", true, AuthMethod.Login);
-					
-					MailMessage message = CreateSimpleMailMessage();
-					uint uid = Client.StoreMessage(message);
-					
-					Console.WriteLine("The UID of the stored mail message is " + uid);
-					
-					Client.Dispose();
-
-					// ...........
-
-					// This creates a simple mail message with a text/plain body and a PNG image
-					// as a file attachment.
-					// Consult the MSDN website for more details on the System.Net.Mail.Mailmessage class.
-					static MailMessage CreateSimpleMailMessage() {
-						MailMessage message = new MailMessage();
-
-						message.From = new MailAddress("someone@someplace.com");
-						message.To.Add("john.doe@someplace.com");
-
-						message.Subject = "This is just a test!";
-						message.Body = "This is the text/plain body. An additional HTML body " +
-							"can optionally be attached as an alternate view";
-
-						// Add the attachment.
-						Attachment attachment = new Attachment("some_image.png", "image/png");
-						attachment.Name = "my_attached_image.png";
-						message.Attachments.Add(attachment);
-
-						return message;
-					}
-				</code>
-			</example>
-		</ImapClient>
-    <ImapClient name="StoreMessage2">
-      <example>
-        This example demonstrates how to store a mail message on an IMAP server without forcing
-        the message body to be broken into 76 char lines as per RFC2822 in order to preserve message formatting.
-        <code>
           ImapClient Client = new ImapClient("imap.gmail.com", 993, "My_UsernamMe",
-          "My_Password", true, AuthMethod.Login);
+          "My_Password", AuthMethod.Login, true);
 
           MailMessage message = CreateSimpleMailMessage();
-          uint uid = Client.StoreMessage(message, //message to store
-            false, //mark the message as unseen
-            null, //use default mailbox
-            false); //do not force breaking of the message body
+          uint uid = Client.StoreMessage(message);
 
           Console.WriteLine("The UID of the stored mail message is " + uid);
 
@@ -401,7 +358,50 @@
 
           message.Subject = "This is just a test!";
           message.Body = "This is the text/plain body. An additional HTML body " +
-          "can optionally be attached as an alternate view. " + 
+          "can optionally be attached as an alternate view";
+
+          // Add the attachment.
+          Attachment attachment = new Attachment("some_image.png", "image/png");
+          attachment.Name = "my_attached_image.png";
+          message.Attachments.Add(attachment);
+
+          return message;
+          }
+        </code>
+			</example>
+		</ImapClient>
+    <ImapClient name="StoreMessage2">
+      <example>
+        This example demonstrates how to store a mail message on an IMAP server without forcing
+        the message body to be broken into 76 char lines as per RFC2822 in order to preserve message formatting.
+        <code>
+          ImapClient Client = new ImapClient("imap.gmail.com", 993, "My_UsernamMe",
+          "My_Password", AuthMethod.Login, true);
+
+          MailMessage message = CreateSimpleMailMessage();
+          uint uid = Client.StoreMessage(message, //message to store
+          false, //mark the message as unseen
+          null, //use default mailbox
+          false); //do not force breaking of the message body
+
+          Console.WriteLine("The UID of the stored mail message is " + uid);
+
+          Client.Dispose();
+
+          // ...........
+
+          // This creates a simple mail message with a text/plain body and a PNG image
+          // as a file attachment.
+          // Consult the MSDN website for more details on the System.Net.Mail.Mailmessage class.
+          static MailMessage CreateSimpleMailMessage() {
+          MailMessage message = new MailMessage();
+
+          message.From = new MailAddress("someone@someplace.com");
+          message.To.Add("john.doe@someplace.com");
+
+          message.Subject = "This is just a test!";
+          message.Body = "This is the text/plain body. An additional HTML body " +
+          "can optionally be attached as an alternate view. " +
           "We also need to add a few more words to the message body in order to see " +
           "whether they get broken by the StoreMessage procedure.";
 

--- a/Examples.xml
+++ b/Examples.xml
@@ -370,5 +370,50 @@
 				</code>
 			</example>
 		</ImapClient>
+    <ImapClient name="StoreMessage2">
+      <example>
+        This example demonstrates how to store a mail message on an IMAP server without forcing
+        the message body to be broken into 76 char lines as per RFC2822 in order to preserve message formatting.
+        <code>
+          ImapClient Client = new ImapClient("imap.gmail.com", 993, "My_UsernamMe",
+          "My_Password", true, AuthMethod.Login);
+
+          MailMessage message = CreateSimpleMailMessage();
+          uint uid = Client.StoreMessage(message, //message to store
+            false, //mark the message as unseen
+            null, //use default mailbox
+            false); //do not force breaking of the message body
+
+          Console.WriteLine("The UID of the stored mail message is " + uid);
+
+          Client.Dispose();
+
+          // ...........
+
+          // This creates a simple mail message with a text/plain body and a PNG image
+          // as a file attachment.
+          // Consult the MSDN website for more details on the System.Net.Mail.Mailmessage class.
+          static MailMessage CreateSimpleMailMessage() {
+          MailMessage message = new MailMessage();
+
+          message.From = new MailAddress("someone@someplace.com");
+          message.To.Add("john.doe@someplace.com");
+
+          message.Subject = "This is just a test!";
+          message.Body = "This is the text/plain body. An additional HTML body " +
+          "can optionally be attached as an alternate view. " + 
+          "We also need to add a few more words to the message body in order to see " +
+          "whether they get broken by the StoreMessage procedure.";
+
+          // Add the attachment.
+          Attachment attachment = new Attachment("some_image.png", "image/png");
+          attachment.Name = "my_attached_image.png";
+          message.Attachments.Add(attachment);
+
+          return message;
+          }
+        </code>
+      </example>
+    </ImapClient>
 	</Imap>
 </S22>

--- a/IImapClient.cs
+++ b/IImapClient.cs
@@ -424,6 +424,7 @@ namespace S22.Imap {
 		/// <param name="mailbox">The mailbox the message will be stored in. If this parameter is
 		/// omitted, the value of the DefaultMailbox property is used to determine the mailbox to store
 		/// the message in.</param>
+        /// <param name="breakBody">Signal whether the message body should be broken into 76 char lines.</param>
 		/// <returns>The unique identifier (UID) of the stored message.</returns>
 		/// <exception cref="ArgumentNullException">The message parameter is null.</exception>
 		/// <exception cref="BadServerResponseException">The mail message could not be stored. The
@@ -439,7 +440,7 @@ namespace S22.Imap {
 		/// the same UID.</remarks>
 		/// <seealso cref="StoreMessages"/>
 		/// <include file='Examples.xml' path='S22/Imap/ImapClient[@name="StoreMessage"]/*'/>
-		uint StoreMessage(MailMessage message, bool seen = false, string mailbox = null);
+        uint StoreMessage(MailMessage message, bool seen = false, string mailbox = null, bool breakBody = true);
 
 		/// <summary>
 		/// Stores the specified mail messages on the IMAP server.
@@ -451,6 +452,7 @@ namespace S22.Imap {
 		/// <param name="mailbox">The mailbox the messages will be stored in. If this parameter is
 		/// omitted, the value of the DefaultMailbox property is used to determine the mailbox to store
 		/// the messages in.</param>
+        /// <param name="breakBody">Signal whether the message body should be broken into 76 char lines.</param>
 		/// <returns>An enumerable collection of unique identifiers (UID) representing the stored
 		/// messages on the server.</returns>
 		/// <exception cref="ArgumentNullException">The messages parameter is null.</exception>
@@ -467,7 +469,7 @@ namespace S22.Imap {
 		/// the same UID.</remarks>
 		/// <seealso cref="StoreMessage"/>
 		IEnumerable<uint> StoreMessages(IEnumerable<MailMessage> messages, bool seen = false,
-			string mailbox = null);
+			string mailbox = null, bool breakBody = true);
 
 		/// <summary>
 		/// Copies the mail message with the specified UID to the specified destination mailbox.

--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -1328,6 +1328,7 @@ namespace S22.Imap {
 		/// <param name="mailbox">The mailbox the messages will be stored in. If this parameter is
 		/// omitted, the value of the DefaultMailbox property is used to determine the mailbox to store
 		/// the messages in.</param>
+        /// <param name="breakBody">Signal whether the message body should be broken into 76 char lines.</param>
 		/// <returns>An enumerable collection of unique identifiers (UID) representing the stored
 		/// messages on the server.</returns>
 		/// <exception cref="ArgumentNullException">The messages parameter is null.</exception>
@@ -1344,11 +1345,12 @@ namespace S22.Imap {
 		/// the same UID.</remarks>
 		/// <seealso cref="StoreMessage"/>
 		public IEnumerable<uint> StoreMessages(IEnumerable<MailMessage> messages, bool seen = false,
-			string mailbox = null) {
+            string mailbox = null, bool breakBody = true)
+        {
 			messages.ThrowIfNull("messages");
 			List<uint> list = new List<uint>();
 			foreach (MailMessage m in messages)
-				list.Add(StoreMessage(m, seen, mailbox));
+				list.Add(StoreMessage(m, seen, mailbox, breakBody));
 			return list;
 		}
 

--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -1276,6 +1276,7 @@ namespace S22.Imap {
 		/// <param name="mailbox">The mailbox the message will be stored in. If this parameter is
 		/// omitted, the value of the DefaultMailbox property is used to determine the mailbox to store
 		/// the message in.</param>
+        /// <param name="breakBody">Signal whether the message body should be broken into 76 char lines.</param>
 		/// <returns>The unique identifier (UID) of the stored message.</returns>
 		/// <exception cref="ArgumentNullException">The message parameter is null.</exception>
 		/// <exception cref="BadServerResponseException">The mail message could not be stored. The
@@ -1291,10 +1292,10 @@ namespace S22.Imap {
 		/// the same UID.</remarks>
 		/// <seealso cref="StoreMessages"/>
 		/// <include file='Examples.xml' path='S22/Imap/ImapClient[@name="StoreMessage"]/*'/>
-		public uint StoreMessage(MailMessage message, bool seen = false, string mailbox = null) {
+		public uint StoreMessage(MailMessage message, bool seen = false, string mailbox = null, bool breakBody = true) {
 			AssertValid();
 			message.ThrowIfNull("message");
-			string mime822 = message.ToMIME822();
+			string mime822 = message.ToMIME822(breakBody);
 			lock (sequenceLock) {
 				PauseIdling();
 				if (mailbox == null)


### PR DESCRIPTION
Hi there,

updated this quality library with an option to disable the line breaking of the message body when storing a message in an IMAP folder, otherwise the can mess up the formating of the message. This violates RFC2822 but might be necessary for text only messages and it appears to work fine.

Excuse the original indentation that appears to be messed up in parts as displayed by github.
