### PR TITLE
Correct sample code typo

### DIFF
--- a/Examples.md
+++ b/Examples.md
@@ -151,7 +151,7 @@
 					// If we're only interested in the subject line or envelope
 					// information, just downloading the mail headers is alot
 					// cheaper and alot faster.
-					IEnumerable<MailMessage> messages = Client.GetMessages(uids. FetchOptions.HeadersOnly);
+					IEnumerable<MailMessage> messages = Client.GetMessages(uids, FetchOptions.HeadersOnly);
 				}
 			}
 		}


### PR DESCRIPTION
Replace a period with a comma in the Client.GetMessages method call
