### PR TITLE
Properly encode the destination mailbox name in CopyMessages()

### DIFF
--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -1628,7 +1628,7 @@ namespace S22.Imap {
 				SelectMailbox(mailbox);
 				string tag = GetTag();
 				string response = SendCommandGetResponse(tag + "UID COPY " + set + " " +
-					destination.QuoteString());
+					Util.UTF7Encode(destination).QuoteString());
 				while (response.StartsWith("*"))
 					response = GetResponse();
 				ResumeIdling();


### PR DESCRIPTION
Fixes issue #112
