### PR TITLE
Update ImapClient.cs

### DIFF
--- a/ImapClient.cs
+++ b/ImapClient.cs
@@ -1628,7 +1628,7 @@ namespace S22.Imap {
 				SelectMailbox(mailbox);
 				string tag = GetTag();
 				string response = SendCommandGetResponse(tag + "UID COPY " + set + " " +
-					destination.QuoteString());
+					Util.UTF7Encode(destination).QuoteString());
 				while (response.StartsWith("*"))
 					response = GetResponse();
 				ResumeIdling();


### PR DESCRIPTION
I'm French (so, sorry for my english). I have mailboxes using accents (eg: "Santé"). 
MailHeaders can be retrieved from this MailBox but moving emails to it fail.
I suggest to encode the name the same way it's done in fetching headers.
It's my first proposal in GitHub so I don't know if you see it, I suggest to modify in:
public void CopyMessages(IEnumerable<uint> uids, string destination, string mailbox = null) {
The retrieval:
string response = SendCommandGetResponse(tag + "UID COPY " + set + " " +
    Util.UTF7Encode(destination).QuoteString());
Looks like it works for me.
